### PR TITLE
Add Adaptive Tab Bar Colour support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,26 @@ git clone https://github.com/RemyIsCool/AnimatedFox chrome
 
 If you would like your tabs to be centered, set the option `animatedFox.centeredTabs` to true in about:config.
 
+## Use with [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) plugin.
+If you want to use this theme with the Adaptive Tab Bar Colour extension instead of Firefox Color, go to the `#nav-bar` section in the `userChrome.css` file and modify it like this:
+
+(Note that the only change is the addition of `background-color: var(--tabpanel-background-color) !important;`)
+
+```css
+#nav-bar {
+	position: fixed !important;
+	top: 0;
+	left: 25%;
+	right: 25%;
+	z-index: 1;
+	transition: top 0.3s cubic-bezier(0.270, 0.910, 0.435, 1.280), opacity 0.1s ease !important;
+	border-top: none !important;
+	border-radius: 10px !important;
+	border: 1px solid var(--tab-selected-bgcolor) !important;
+	opacity: 0;
+	background-color: var(--tabpanel-background-color) !important;
+}
+```
+
 ---
 For the new tab page, see https://github.com/RemyIsCool/New-Tab-Page.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone https://github.com/RemyIsCool/AnimatedFox chrome
 
 If you would like your tabs to be centered, set the option `animatedFox.centeredTabs` to true in about:config.
 
-If you want to use this theme with the [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) extension instead of Firefox Color, set the option `animatedFox.adaptiveTabBarColorSupport` to true in about:config.
+If you want to use this theme with the [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) extension instead of Firefox Color, set the option `animatedFox.adaptiveTabBarColourSupport` to true in about:config.
 
 ---
 For the new tab page, see https://github.com/RemyIsCool/New-Tab-Page.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/RemyIsCool/AnimatedFox/assets/97812130/7c1ea741-5b01-4e7f-892
 ## 🖥️ Requirements
  - 🦊 An up-to-date version of Firefox or LibreWolf. Other Firefox derivatives might work but I haven't tested them.
  - 🔤 [JetBrains Mono](https://www.jetbrains.com/lp/mono/) installed on your system.
- - 🎨 [Firefox Color extention](https://addons.mozilla.org/en-CA/firefox/addon/firefox-color/) added to your browser. (Optional)
+ - 🎨 [Firefox Color extension](https://addons.mozilla.org/en-CA/firefox/addon/firefox-color/) added to your browser. (Optional)
 
 ## ⬇️ Installation
 1. ✅ Make sure you have everything listed in Requirements.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone https://github.com/RemyIsCool/AnimatedFox chrome
 
 If you would like your tabs to be centered, set the option `animatedFox.centeredTabs` to true in about:config.
 
-If you want to use this theme with the [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) extension instead of Firefox Color, set the option `animatedFox.adaptiveTabBarColourSupport` to true in about:config.
+If you want to use this theme with the [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) extension instead of Firefox Color, set the option `animatedFox.adaptiveTabBarColourSupport` to true in about:config. If you do this, you do not need to install the Firefox Color theme.
 
 ---
 For the new tab page, see https://github.com/RemyIsCool/New-Tab-Page.

--- a/README.md
+++ b/README.md
@@ -23,26 +23,7 @@ git clone https://github.com/RemyIsCool/AnimatedFox chrome
 
 If you would like your tabs to be centered, set the option `animatedFox.centeredTabs` to true in about:config.
 
-## Use with [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) plugin.
-If you want to use this theme with the Adaptive Tab Bar Colour extension instead of Firefox Color, go to the `#nav-bar` section in the `userChrome.css` file and modify it like this:
-
-(Note that the only change is the addition of `background-color: var(--tabpanel-background-color) !important;`)
-
-```css
-#nav-bar {
-	position: fixed !important;
-	top: 0;
-	left: 25%;
-	right: 25%;
-	z-index: 1;
-	transition: top 0.3s cubic-bezier(0.270, 0.910, 0.435, 1.280), opacity 0.1s ease !important;
-	border-top: none !important;
-	border-radius: 10px !important;
-	border: 1px solid var(--tab-selected-bgcolor) !important;
-	opacity: 0;
-	background-color: var(--tabpanel-background-color) !important;
-}
-```
+If you want to use this theme with the [Adaptive Tab Bar Colour](https://github.com/easonwong-de/Adaptive-Tab-Bar-Colour) extension instead of Firefox Color, set the option `animatedFox.adaptiveTabBarColorSupport` to true in about:config.
 
 ---
 For the new tab page, see https://github.com/RemyIsCool/New-Tab-Page.

--- a/userChrome.css
+++ b/userChrome.css
@@ -30,6 +30,12 @@
 	opacity: 0;
 }
 
+@media (-moz-bool-pref: "animatedFox.adaptiveTabBarColourSupport") {
+	#nav-bar {
+		background-color: var(--tabpanel-background-color) !important;
+	}
+}
+
 #navigator-toolbox {
 	border-bottom: none !important;
 }


### PR DESCRIPTION
How the change in the note works with the Firefox Color plugin **and** Adaptive Bar Colour enabled
<img width="788" alt="Screenshot 2024-06-29 at 12 00 24 p m" src="https://github.com/RemyIsCool/AnimatedFox/assets/79347623/0b589127-549a-4234-bdc9-105c75ed52f6">

How the change works with **only** the Adaptive Bar Colour plugin enabled
<img width="740" alt="Screenshot 2024-06-29 at 12 01 19 p m" src="https://github.com/RemyIsCool/AnimatedFox/assets/79347623/3b585186-0a12-4ffb-a0c6-bcadfcf28396">
